### PR TITLE
remove violet blue from en word list

### DIFF
--- a/localResources/en.json
+++ b/localResources/en.json
@@ -322,7 +322,6 @@
   "vagina",
   "venus mound",
   "vibrator",
-  "violet blue",
   "violet wand",
   "vorarephilia",
   "voyeur",

--- a/swearWords.json
+++ b/swearWords.json
@@ -322,7 +322,6 @@
   "vagina",
   "venus mound",
   "vibrator",
-  "violet blue",
   "violet wand",
   "vorarephilia",
   "voyeur",


### PR DESCRIPTION
it's a person's name, not a vulgar word.