### PR TITLE
feat: reduce the accesses to localStorage

### DIFF
--- a/jquery.profanityfilter.js
+++ b/jquery.profanityfilter.js
@@ -134,11 +134,13 @@
 
             if (options.externalSwears !== null) {
                 if (localStorageIsEnabled) {
-                    if (localStorage.getItem(localSwearsKey) === null) {
+                    var badWordsJSON = localStorage.getItem(localSwearsKey);
+                    if (badWordsJSON === null) {
                         // stringify the array so that it can be stored in local storage
-                        localStorage.setItem(localSwearsKey, JSON.stringify(readJsonFromController(options.externalSwears)));
+                        badWordsJSON = JSON.stringify(readJsonFromController(options.externalSwears));
+                        localStorage.setItem(localSwearsKey, badWordsJSON);
                     }
-                    badWords = JSON.parse(localStorage.getItem(localSwearsKey));
+                    badWords = JSON.parse(badWordsJSON);
                 } else {
                     badWords = readJsonFromController(options.externalSwears);
                 }
@@ -195,4 +197,4 @@
             };
         });
     };
-})(jQuery);
+})(jQuery);


### PR DESCRIPTION
I know that localStorage might already be loaded in memory (instead of being accessed from the disk) and be super-fast to access, but this essentially halves the accesses.